### PR TITLE
Add comprehensive notes glossary to how-to-use.md

### DIFF
--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -1,3 +1,171 @@
 # How to use this site
 
-Coming soon!
+Welcome to the **Threejs Journey Notes** glossary! This page serves as a comprehensive index of all the learning resources, tutorials, recipes, and notes available on this site.
+
+Whether you are looking for specific frontend features, backend design patterns, DevOps automation, AI engineering strategies, or 3D graphics (Three.js), use the glossary below to find exactly what you need and jump straight to that guide.
+
+---
+
+## 🔍 Table of Contents
+
+- [🌐 Frontend Development & JavaScript](#-frontend-development--javascript)
+- [🖥️ Backend Engineering & APIs](#%EF%B8%8F-backend-engineering--apis)
+- [☁️ DevOps, Cloud & Infrastructure](#%EF%B8%8F-devops-cloud--infrastructure)
+- [📐 3D Graphics & WebGL (Three.js)](#-3d-graphics--webgl-threejs)
+- [🧠 Artificial Intelligence & Prompt Engineering](#-artificial-intelligence--prompt-engineering)
+- [🗄️ Databases & Caching](#%EF%B8%8F-databases--caching)
+- [🐧 Linux, Shell & Developer Productivity](#-linux-shell--developer-productivity)
+- [💼 Product Development & Software Craftsmanship](#-product-development--software-craftsmanship)
+
+---
+
+## 🌐 Frontend Development & JavaScript
+
+Learn core JavaScript APIs, CSS recipes, modern frameworks, accessibility standards, performance optimizations, and progressive web apps (PWAs).
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **JavaScript Proxies** | [Vanilla JS Tutorial: Advanced APIs](./vanilla-js-tutorial/09-advanced-js-APIs.md#proxies) | Learn reactive programming, validating/protecting data, caching proxies, and dispatching custom events with Proxies. |
+| **Web Components & Lit** | [Vanilla JS Tutorial: Advanced APIs](./vanilla-js-tutorial/09-advanced-js-APIs.md#web-components) | Guide on shadow DOM, custom templates, lifecycle methods (`connectedCallback`), and Lit library usage. |
+| **Advanced Browser APIs** | [Vanilla JS Tutorial: Advanced APIs](./vanilla-js-tutorial/09-advanced-js-APIs.md) | Covering AbortController, Eyedropper API, Geolocation, FileSystem API, Web Payments, Web Audio, and WakeLock. |
+| **Progressive Web Apps (PWA)** | [Vanilla JS Tutorial: PWA](./vanilla-js-tutorial/11-PWA.md) | Comprehensive guide on service workers, caching strategies, background sync, push notifications, and iOS/Android notches. |
+| **React Basics & State** | [JS Frameworks: React](./js-frameworks/01-react.md) | Learn React fundamentals, when to use state, rendering optimization, and hooks. |
+| **Next.js & Server Components** | [JS Frameworks: Next.js](./js-frameworks/02-next-js.md) | Understand Server Components vs Client Components and nesting rules/tricks. |
+| **Solid.js & Signals** | [JS Frameworks: Solid.js](./js-frameworks/05-solid-js.md) | Deep-dive into reactivity from first principles and writing your own signals from scratch. |
+| **Astro Framework** | [JS Frameworks: Astro](./js-frameworks/06-astro.md) | Learn Astro's file-based routing, layout composition, and performance patterns. |
+| **TanStack Start & Router** | [JS Frameworks: TanStack Start](./js-frameworks/11-tanstack-start.md) | Safe routing on the fly, type definitions generation, and modern Router composition. |
+| **TSRX** | [JS Frameworks: TSRX](./js-frameworks/10-tsrx.md) | Introduction to the language-agnostic way of writing colocated JSX. |
+| **TypeScript Basics** | [TS Tutorial: Basics](./typescript-tutorial/01-typescript-basics.md) | Handbook on config options, compiler setups, and type-system core features. |
+| **Declaration Files (`.d.ts`)** | [TS Tutorial: Declaration Files](./typescript-tutorial/02-declaration-files.md) | How to add global types and handle prototype augmentation safely. |
+| **JSDoc in TypeScript** | [TS Tutorial: JSDoc](./typescript-tutorial/03-JSDOC.md) | Documenting functions and types using native JSDoc comments. |
+| **Advanced TypeScript Tricks** | [TS Tutorial: Other Tricks](./typescript-tutorial/05-other-typescript-tricks.md) | Learn advanced topics like Private Property Async Initialization. |
+| **Vanilla JS Cookbook** | [JS Cookbook](./js-cookbook/11-Vanilla-js-cookbook.md) | Quick snippets for custom UI features like text animations. |
+| **Chrome Extensions** | [Chrome Extensions: Intro](./chrome-extensions/01-intro.md) | Basics of building browser extensions, action APIs, and using the Plasmo framework. |
+| **Tailwind CSS & Snippets** | [CSS Recipes: Basic CSS](./css-recipes/00-basic-CSS.md) | Modern web design recipes, beautiful CSS snippets, shadows, and Tailwind merge strategies. |
+| **Web Accessibility (a11y)** | [Vanilla JS Tutorial: Accessibility](./vanilla-js-tutorial/14-accessibility.md) | Learn essential rules to make your web applications fully accessible. |
+| **Web Performance & SEO** | [Vanilla JS Tutorial: Web Performance](./vanilla-js-tutorial/12-web-performance.md) | Techniques for fast initial loads, optimizing assets, and HTML DOM SEO best practices. |
+
+---
+
+## 🖥️ Backend Engineering & APIs
+
+Build fast, scalable, and secure backend systems, publish CLI tools, and design resilient APIs.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **Node.js Streams** | [Node: Streams](./node/02-node-streams.md) | Harness the Event Emitter API, event-driven architecture, and read/write streams. |
+| **Express.js API Guide** | [Node: Complete Express Guide](./node/15-complete-express-guide.md) | Step-by-step master guide to creating routing, middleware, and full Express servers. |
+| **API Architecture & Design** | [Node: API Design](./node/14-API-design.md) | How to manage configuration constants across development, testing, and production environments. |
+| **GraphQL** | [Node: GraphQL](./node/12-GraphQL.md) | Learn GraphQL schema definitions and why it scales better for highly relational datasets than REST. |
+| **Command Line (CLI) Tools** | [Node: Publishing NPM CLI Tools](./node/08-publishing-npm-cli-tools.md) | Create interactive Node.js CLI tools and publish them as global packages on NPM. |
+| **SQLite with Node** | [Node: SQLite](./node/13-node-sqlite.md) | Learn to integrate and use lightweight, embedded SQLite databases in server applications. |
+| **System Design Foundations** | [Backend Engineering: System Design](./backend-engineering/03-system-design.md) | Architecture patterns, monoliths vs microservices, and general scale techniques. |
+| **Backend Communication Patterns** | [Backend Engineering: Theory](./backend-engineering/04-backend-theory.md) | Deep-dive into Request/Response, Server-Sent Events, WebSockets, and packet anatomy. |
+| **WebSockets** | [Node: Sockets](./node/10-sockets.md) | Set up socket servers and handle realtime duplex channels for active clients. |
+| **Deno Basics & Frameworks** | [Deno: Basics](./deno/01-basics.md) | Explore the standard library, file sandboxing, backend testing, and frameworks like Oak. |
+| **Bun & Hono** | [Bun Tutorial: Basics](./bun-tutorial/01-Bun-Basics.md) | Learn Bun APIs, serving HTTP, Dockerizing Bun, and deploying serverless on Vercel. |
+| **C# & ASP.NET Basics** | [C-Sharp: Basics](./C-sharp/01-C-sharp-basics.md) | Get up to speed on .NET core, building CLI apps, C# extensions, and setting up ASP.NET servers. |
+
+---
+
+## ☁️ DevOps, Cloud & Infrastructure
+
+Automate deployment pipelines, orchestrate containers, provision cloud instances, and manage infrastructure as code.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **Docker Containers** | [DevOps: Docker](./devops/01-Docker.md) | Introduction to containers from scratch, writing Dockerfiles, and managing volumes. |
+| **GitHub Actions (CI/CD)** | [DevOps: GitHub Actions](./devops/07-github-actions.md) | Automation pipelines, configuring workflow triggers, and writing modular jobs. |
+| **Ansible Automation** | [DevOps: Ansible](./devops/05-ansible.md) | Write declarative YAML playbooks to configure networks, servers, and remote nodes. |
+| **AWS Fundamentals** | [AWS Tutorial](./AWS/AWS%20tutorial.md) | Core cloud architecture: Regions, Availability Zones, and high availability fundamentals. |
+| **AWS CloudFormation** | [AWS: CloudFormation](./AWS/AWS-cloudformation.md) | Declarative Infrastructure as Code (IaC) solutions specifically targeting AWS resources. |
+| **AWS Cloud Development Kit (CDK)** | [AWS: CDK](./AWS/AWS-CDK.md) | Build scalable AWS environments using modern TypeScript APIs rather than verbose YAML. |
+| **AWS Serverless (SAM)** | [AWS: SAM IaC](./AWS/AWS-IaC.md) | Deploying serverless functions, gateways, and DBs with AWS SAM syntax. |
+| **AWS Amplify** | [AWS: Amplify](./AWS/AWS-amplify.md) | Compare Gen 1 vs Gen 2 setups, and learn how to quickly configure authentication and APIs. |
+| **AWS SDK & CLI Auth** | [AWS: SDK & CLI](./AWS/AWS-SDK-CLI.md) | Authenticating terminal clients, scripting AWS actions, and using the SDK in apps. |
+| **Vercel & App Deployment** | [DevOps: Deploying Apps](./devops/06-deploying-apps.md) | Best practices to host frontends, SPAs, and fullstack servers (like Express) on Vercel. |
+| **NGINX Reverse Proxy** | [Backend Engineering: Fullstack Engineering](./backend-engineering/09-Fullstack-Engineering.md) | Configure Nginx as a reverse proxy, load balancer, and secure static file server. |
+
+---
+
+## 📐 3D Graphics & WebGL (Three.js)
+
+Master the math, physics, lights, and rendering engines behind immersive 3D experiences in the browser.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **Three.js Basic Scene** | [ThreeJS Tutorial: Basic Scene](./threejs-tutorial/03-basic-scene.md) | Learn to initialize your first scene, camera, renderer, and mesh. |
+| **Transformations** | [ThreeJS Tutorial: Transformations](./threejs-tutorial/05-transformations.md) | How to manipulate position, rotation, scale, and work with quaternions. |
+| **Animations & Resize** | [ThreeJS Tutorial: Animations](./threejs-tutorial/06-animations.md) | Using `requestAnimationFrame`, tick functions, and making the viewport responsive. |
+| **Cameras & Responsive Design** | [ThreeJS Tutorial: Cameras](./threejs-tutorial/07-cameras.md) | Understand Orthographic vs Perspective cameras, and multiplayer split-screens. |
+| **Geometries & Vertices** | [ThreeJS Tutorial: Geometry](./threejs-tutorial/09-geometry.md) | Harnessing `BufferGeometry` to manipulate triangles and custom vertices in 3D. |
+| **Textures & Materials** | [ThreeJS Tutorial: Textures](./threejs-tutorial/11-textures.md) | Mapping colors, normal maps, roughness, metalness, and configuring realistic materials. |
+| **3D Text rendering** | [ThreeJS Tutorial: 3D Text](./threejs-tutorial/13-text.md) | Generating 3D typography using facetype JSON fonts and TextGeometry. |
+| **Lights & Shadows** | [ThreeJS Tutorial: Lights](./threejs-tutorial/15-lights.md) | Ambient lights, Directional lights, Point lights, and configuring drop vs core shadows. |
+| **Debugging with GUI** | [ThreeJS Tutorial: Debugging](./threejs-tutorial/10-debugging.md) | Connect `lil-gui` to dynamically tweak scene variables, mesh coordinates, and lighting. |
+
+---
+
+## 🧠 Artificial Intelligence & Prompt Engineering
+
+Level up your workflows with prompt engineering, AI development patterns, and LLM automation.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **Prompt Engineering Basics** | [AI Engineering: Prompt Engineering](./ai-engineering/04-prompt-engineering.md) | The 4 essential ingredients of any successful prompt. |
+| **AI Agentic Workflows** | [AI Engineering: Agentic AI Development](./ai-engineering/05-agentic-AI-development.md) | Constructing autonomous agents, system loops, tools, and execution contexts. |
+| **AI assisted Coding** | [AI Engineering: AI Slop Mastery](./ai-engineering/06-AI-slop-mastery.md) | Optimal workflows for context isolation and writing high-quality code. |
+| **Claude & Anthropic Tips** | [AI Engineering: Anthropic Slop Mastery](./ai-engineering/01-Anthropic-slop-mastery.md) | Advanced prompting strategies specific to Anthropic's Claude models. |
+| **Claude Code & CLI Tools** | [AI Engineering: Claude Code](./ai-engineering/08-claude-code.md) | Using modern automated terminals for code updates and refactoring. |
+
+---
+
+## 🗄️ Databases & Caching
+
+Store, retrieve, index, and cache data with high-performance engines.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **SQL & PostgreSQL** | [Databases: SQL](./databases/03-sql.md) | Schema creation, indexes, joins, and running migrations. |
+| **MongoDB Shell** | [Databases: MongoDB](./databases/07-mongo.md) | Managing documents, writing aggregation pipelines, and Dockerized setups. |
+| **Redis Caching** | [Databases: Redis](./databases/08-redis.md) | Supercharge API performance with key-value memory caches and expiration rules. |
+| **IndexedDB (IDB & localForage)**| [Vanilla JS Tutorial: PWA](./vanilla-js-tutorial/11-PWA.md#indexeddb) | Persisting gigabytes of object data offline directly inside the browser. |
+
+---
+
+## 🐧 Linux, Shell & Developer Productivity
+
+Master command-line interfaces, automate tasks with bash, and configure advanced environments.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **Vim & Terminal Editing** | [Linux: Vim](./linux/09-vim.md) | Mastering keys, buffers, insert modes, and efficient text manipulation. |
+| **Tmux Terminal Multiplexer** | [Linux: Tmux](./linux/05-tmux.md) | Manage complex workflows, split screens, and persist remote sessions. |
+| **Bash Scripting** | [Linux: Bash Scripting](./linux/04-bash-scripting.md) | Writing `.sh` executable scripts to chain automation commands together. |
+| **FFmpeg Video Compression** | [Linux: FFmpeg](./linux/02-ffmpeg.md) | Transcoding videos, squeezing megabytes, and formatting codecs via command line. |
+| **Git & Version Control** | [Linux: Git](./linux/01-git.md) | Branch strategies, merging, rebasing, and managing git staging hooks. |
+| **WSL (Windows Subsystem)** | [Linux: WSL](./linux/11-wsl.md) | Cross-operating system filesystems and maximizing read/write performance. |
+
+---
+
+## 💼 Product Development & Software Craftsmanship
+
+Design beautiful apps, practice Test-Driven Development, write outstanding technical content, and manage software careers.
+
+| What do you want to learn? | Where to find it on this site | Description / Key Highlights |
+| :--- | :--- | :--- |
+| **Clean Code Guides** | [Software Development: Clean Code](./software-development/01-clean-code.md) | Function design, code smell eradication, readability, and modular design. |
+| **Test-Driven Development (TDD)**| [Software Development: TDD](./software-development/08-TDD.md) | Writing robust, regression-free units by practicing red-green refactoring. |
+| **Technical Writing Guide** | [Software Development: Technical Writing](./software-development/10-technical-writing-guide.md) | Keep things simple, punchy, and structured for your reader. |
+| **Figma Basics** | [Software Development: Figma](./software-development/09-figma.md) | Mastering shortcut keys, layout frames, and components. |
+| **Career & Startups** | [Product Development: All About Startups](./product-development/2-all-about-startups.md) | Launching digital products, finding market fit, and landing tech jobs. |
+
+---
+
+## 💡 Quick Tips for First-Time Users
+
+1. **Use the Search Bar:** This site has integrated DocSearch (Algolia). Just click search (or hit `Ctrl + K` / `Cmd + K`) to immediately lookup any term or class from these notes.
+2. **Interactive Code Examples:** Many codeblocks inside our notes contain syntax-highlighted code. You can copy them directly using the copy button on the top right of each codeblock.
+3. **Follow Sidebar Structure:** If you're completely new, we recommend checking out [Docusaurus Notes](./mynotes.md) or checking the sidebar on the left to see the natural progression of topics.
+
+Happy learning! 🚀


### PR DESCRIPTION
A comprehensive, fully-linked notes glossary has been successfully created in `docs/how-to-use.md`. The glossary categorizes topics such as Frontend, Backend, DevOps & Cloud, 3D Graphics (Three.js), AI, Databases, Linux, and Career into a searchable index mapping specific learning goals directly to their documentation source files. Docusaurus build link check and Playwright E2E tests have both been fully verified.

Fixes #5

---
*PR created automatically by Jules for task [12066489833728011887](https://jules.google.com/task/12066489833728011887) started by @aadilmallick*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the placeholder usage guide with a comprehensive Threejs Journey Notes glossary and how-to index.
  * Added categorized navigation, guide links, key learning highlights, and quick-start instructions for first-time users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->